### PR TITLE
feat: Make Dataset truly renderless

### DIFF
--- a/src/Dataset.vue
+++ b/src/Dataset.vue
@@ -1,7 +1,5 @@
 <template>
-  <div>
-    <slot :ds="{ dsShowEntries, dsResultsNumber, dsPage, dsPagecount, dsFrom, dsTo, dsData, dsRows, dsPages }"></slot>
-  </div>
+  <slot :ds="{ dsShowEntries, dsResultsNumber, dsPage, dsPagecount, dsFrom, dsTo, dsData, dsRows, dsPages }"></slot>
 </template>
 
 <script>


### PR DESCRIPTION
BREAKING CHANGE do not render a div anymore for `Dataset`

--

@kouts Sorry I meant to open the PR towards `next`.

This PR is to `next`!