### PR TITLE
refactor: prevent clash with nested `val` with same variable name

### DIFF
--- a/src/Dataset.vue
+++ b/src/Dataset.vue
@@ -117,7 +117,7 @@ export default {
 
     watch(
       whenChanged,
-      (val, oldVal) => {
+      (newVal, oldVal) => {
         let result = []
 
         if (!dsSearch.value && !props.dsSortby.length && isEmptyObject(props.dsFilterFields)) {


### PR DESCRIPTION
even though this is not causing any issues. It's always good to prevent usage of the same variable names in the same scope