### PR TITLE
fix: updating the visible rows with showEntries() should refresh the table

### DIFF
--- a/src/Dataset.vue
+++ b/src/Dataset.vue
@@ -93,6 +93,7 @@ export default {
       props.dsSearchIn
       props.dsSearchAs
       props.dsSortAs
+      dsShowEntries.value
       return Date.now()
     })
 


### PR DESCRIPTION
expected:
- updating the visible rows with `showEntries()` should refresh the table

current behaviour:
- when changing the visible row count with `showEntries` eg. from 5 → 6 (`showEntries(6)`), the table UI doesn't refresh, so the new row doesn't become visible