### PR TITLE
feat: exposed indexes to scope as `dsIndexes`

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -145,9 +145,19 @@ You can leverage these using `inject` to create your own **custom child componen
   </thead>
   <tbody>
     <tr>
+      <td>dsData</td>
+      <td>Array of Objects</td>
+      <td>The data object that contains all the data</td>
+    </tr>  
+    <tr>
+      <td>dsIndexes</td>
+      <td>Array</td>
+      <td>The indexes of all the filtered data rows, regardless of paging</td>
+    </tr>  
+    <tr>
       <td>dsRows</td>
       <td>Array</td>
-      <td>The indexes of the data rows currently displaying</td>
+      <td>The indexes of the data rows in the current displayed page</td>
     </tr>
     <tr>
       <td>dsPages</td>
@@ -180,10 +190,10 @@ You can leverage these using `inject` to create your own **custom child componen
       <td>The number of the current page in pagination</td>
     </tr>
     <tr>
-      <td>dsData</td>
-      <td>Array of Objects</td>
-      <td>The data object that contains all the data.</td>
-    </tr>
+      <td>dsShowEntries</td>
+      <td>Number</td>
+      <td>The number of items to show in pagination</td>
+    </tr>    
     <tr>
       <td>datasetI18n</td>
       <td>Object</td>
@@ -262,17 +272,32 @@ Dataset also provides several data via a `ds` object exposed from a a scoped slo
     <tr>
       <td>dsData</td>
       <td>Array of Objects</td>
-      <td>The data object that contains all the data.</td>
+      <td>The data object that contains all the data</td>
+    </tr>
+    <tr>
+      <td>dsIndexes</td>
+      <td>Array</td>
+      <td>The indexes of all the filtered data rows, regardless of paging</td>
     </tr>
     <tr>
       <td>dsRows</td>
       <td>Array</td>
-      <td>The indexes of the data rows currently displaying</td>
+      <td>The indexes of the data rows in the current displayed page</td>
     </tr>
+    <tr>
+      <td>dsPages</td>
+      <td>Array</td>
+      <td>The array used to create pagination links</td>
+    </tr>    
     <tr>
       <td>dsResultsNumber</td>
       <td>Number</td>
       <td>The number of rows currently displaying</td>
+    </tr>
+    <tr>
+      <td>dsPagecount</td>
+      <td>Number</td>
+      <td>The number of pagination pages</td>
     </tr>
     <tr>
       <td>dsFrom</td>
@@ -283,16 +308,6 @@ Dataset also provides several data via a `ds` object exposed from a a scoped slo
       <td>dsTo</td>
       <td>Number</td>
       <td>The item "to" of paginated items currently displaying</td>
-    </tr>
-    <tr>
-      <td>dsPages</td>
-      <td>Array</td>
-      <td>The array used to create pagination links</td>
-    </tr>
-    <tr>
-      <td>dsPagecount</td>
-      <td>Number</td>
-      <td>The number of pagination pages</td>
     </tr>
     <tr>
       <td>dsPage</td>

--- a/src/Dataset.vue
+++ b/src/Dataset.vue
@@ -1,6 +1,7 @@
 <template>
   <slot
     :ds="{
+      dsIndexes,
       dsShowEntries,
       dsResultsNumber,
       dsPage,
@@ -179,6 +180,7 @@ export default {
     provide('dsPage', dsPage)
 
     return {
+      dsIndexes: indexes,
       dsShowEntries,
       dsResultsNumber,
       dsPage,

--- a/src/Dataset.vue
+++ b/src/Dataset.vue
@@ -53,11 +53,11 @@ export default {
   /**
    * @param {{
    *   dsData: Record<string, any>[];
-   *   dsFilterFields: { [fieldId in string]: (cellValue: any) => boolean | any };
+   *   dsFilterFields: { [fieldId in string]: (columnValue: any) => boolean | any };
    *   dsSortby: string[];
    *   dsSearchIn: string[];
-   *   dsSearchAs: { [id in string]: (cellValue: any, searchString: string) => boolean };
-   *   dsSortAs: { [id in string]: (cellValue: any) => any };
+   *   dsSearchAs: { [id in string]: (columnValue: any, searchString: string) => boolean };
+   *   dsSortAs: { [id in string]: (columnValue: any) => any };
    * }} props
    */
   setup(props) {
@@ -65,7 +65,7 @@ export default {
     const dsSearch = ref('')
     const dsShowEntries = ref(10)
     const datasetI18n = ref(i18n)
-    const indexes = ref([])
+    const dsIndexes = ref([])
 
     const search = (value) => {
       dsSearch.value = value
@@ -98,7 +98,7 @@ export default {
     })
 
     const dsRows = computed(() => {
-      return indexes.value.slice(dsFrom.value, dsTo.value)
+      return dsIndexes.value.slice(dsFrom.value, dsTo.value)
     })
 
     const dsPages = computed(() => {
@@ -106,7 +106,7 @@ export default {
     })
 
     const dsResultsNumber = computed(() => {
-      return indexes.value.length
+      return dsIndexes.value.length
     })
 
     const dsPagecount = computed(() => {
@@ -156,13 +156,14 @@ export default {
           // We need only the indexes
           result = result.map((entry) => entry.index)
         }
-        indexes.value = result
+        dsIndexes.value = result
       },
       {
         immediate: true
       }
     )
 
+    provide('dsIndexes', dsIndexes)
     provide('search', search)
     provide('showEntries', showEntries)
     provide('setActive', setActive)
@@ -180,7 +181,7 @@ export default {
     provide('dsPage', dsPage)
 
     return {
-      dsIndexes: indexes,
+      dsIndexes,
       dsShowEntries,
       dsResultsNumber,
       dsPage,


### PR DESCRIPTION
there are times when we need to know the entire array of filtered results of a table through the scope.

Currently we can get:
- all non-filtered rows
- all filtered rows _for the current page_

So I added the `indexes` so we can get:
- all filtered rows _for all pages_